### PR TITLE
[cmake] rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(PACKAGE_CONFIG_PATH)
   set(ENV{PKG_CONFIG_PATH} ${PACKAGE_CONFIG_PATH})
 endif()
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(OpenGL REQUIRED)
 
 if(NOT APPLE)

--- a/visualization.projectm/addon.xml.in
+++ b/visualization.projectm/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.projectm"
-  version="1.0.17"
+  version="1.1.0"
   name="projectM"
   provider-name="Team XBMC">
   <extension


### PR DESCRIPTION
Package renaming is needed after https://github.com/xbmc/xbmc/pull/9750 goes in.