### PR TITLE
fix download path for ftgl & projectm

### DIFF
--- a/depends/linux/ftgl/ftgl.txt
+++ b/depends/linux/ftgl/ftgl.txt
@@ -1,1 +1,1 @@
-ftgl http://heanet.dl.sourceforge.net/project/ftgl/FTGL%20Source/2.1.2/ftgl-2.1.2.tar.gz
+ftgl https://sourceforge.net/projects/ftgl/files/FTGL%20Source/2.1.2/ftgl-2.1.2.tar.gz

--- a/depends/linux/projectm/projectm.txt
+++ b/depends/linux/projectm/projectm.txt
@@ -1,1 +1,1 @@
-projectm http://heanet.dl.sourceforge.net/project/projectm/libprojectM/libprojectM-2.0.0/libprojectM-2.0.0-Source.tar.gz
+projectm https://sourceforge.net/projects/projectm/files/libprojectM/libprojectM-2.0.0/libprojectM-2.0.0-Source.tar.gz

--- a/depends/osx/projectm/projectm.txt
+++ b/depends/osx/projectm/projectm.txt
@@ -1,1 +1,1 @@
-projectm http://heanet.dl.sourceforge.net/project/projectm/libprojectM/libprojectM-2.0.0/libprojectM-2.0.0-Source.tar.gz
+projectm https://sourceforge.net/projects/projectm/files/libprojectM/libprojectM-2.0.0/libprojectM-2.0.0-Source.tar.gz


### PR DESCRIPTION
never use a mirror specific url also the reason for failing to download seems a general change in url layout at sourceforge.
Please also create a new release after this PR is merged that version for Krypton can be bumped at https://github.com/xbmc/repo-binary-addons/blob/Krypton/visualization.projectm/visualization.projectm.txt