### PR TITLE
fix includes (fixes build after https://github.com/xbmc/xbmc/pull/12011)

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -54,7 +54,6 @@ d4rk@xbmc.org
 */
 
 #include <xbmc_vis_dll.h>
-#include <xbmc_addon_cpp_dll.h>
 #include <libXBMC_addon.h>
 #include <threads/mutex.h>
 


### PR DESCRIPTION
fixes

    src/Main.cpp:57:32: fatal error: xbmc_addon_cpp_dll.h: No such file or directory

builds and works fine afterwards.

