### PR TITLE
fix jenkins build

### DIFF
--- a/depends/linux/projectm/08-fix-linux-include.patch
+++ b/depends/linux/projectm/08-fix-linux-include.patch
@@ -1,0 +1,10 @@
+--- projectm/Common.hpp.orig	2009-12-01 07:38:42.000000000 +0100
++++ projectm/Common.hpp	2017-05-15 15:41:12.743838926 +0200
+@@ -55,6 +55,7 @@
+ 
+ #ifdef LINUX
+ #include <cstdlib>
++#include <math.h>
+ #define projectM_isnan isnan
+ 
+ #endif


### PR DESCRIPTION
On last jenkins it fails with:
```
/home/jenkins/workspace/LINUX-64/tools/depends/target/binary-addons/x86_64-linux-gnu-debug/build/projectm/src/projectm/Renderer/BeatDetect.cpp:162:20: error: ‘isnan’ was not declared in this scope
    if ( projectM_isnan( mid ) ) {
                    ^
```
Here at home it works, but normally have `isnan` math.h as include, maybe
this fix it.

Here the jenkins build: http://jenkins.kodi.tv/job/LINUX-64/3844/