### PR TITLE
Allow available preset folder selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
 # build artifacts
 build/
-obj-x86_64-linux-gnu/
 visualization.*/addon.xml
+
+# Debian build files
+debian/changelog
+debian/files
+debian/*.log
+debian/*.substvars
+debian/.debhelper/
+debian/tmp/
+debian/kodi-visualization-*/
+obj-x86_64-linux-gnu/
 
 # commonly used editors
 # vim
@@ -26,5 +35,8 @@ visualization.*/addon.xml
 # clion
 .idea/
 
-# KDev
-*.kdev4
+# to prevent add after a "git format-patch VALUE" and "git add ." call
+/*.patch
+
+# to prevent add if project code opened by Visual Studio over CMake file
+.vs/

--- a/depends/common/projectm/0001-allow-separate-folder-structure-of-presets-during-in.patch
+++ b/depends/common/projectm/0001-allow-separate-folder-structure-of-presets-during-in.patch
@@ -1,0 +1,75 @@
+From f8365f45e7d4debbf6bdf9f7edc220c5009cdd63 Mon Sep 17 00:00:00 2001
+From: Alwin Esch <alwin.esch@web.de>
+Date: Sun, 6 Oct 2019 09:58:31 +0200
+Subject: [PATCH] allow separate folder structure of presets during install
+
+This is intended to install the folders as deposited at the source. If the backend is used then the desired folder will be selected.
+
+This allows a better overlay of the available presets and avoids overwriting the same filenames in different folders during installation.
+
+New configure value "--enable-preset-subdirs"
+---
+ Makefile.am  |  4 ++++
+ configure.ac | 10 ++++++++++
+ 2 files changed, 14 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index 6bb55d9a..a9789f3d 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -19,8 +19,12 @@ pm_font__DATA = fonts/Vera.ttf fonts/VeraMono.ttf
+ 
+ # find and install all preset files
+ install-data-local:
++if ENABLE_PRESET_SUBDIRS
++	find "$(PRESETSDIR)" -type f -exec install -Dm 755 "{}" "$(DESTDIR)/$(pm_data_dir)/{}" \;
++else
+ 	test -z $(DESTDIR)$(pkgdatadir) || $(MKDIR_P) $(DESTDIR)$(pm_presets_dir)
+ 	find "$(PRESETSDIR)" -type f -print0 | LC_ALL=C sort -z | xargs -0 '-I{}' $(INSTALL_DATA) '{}' $(DESTDIR)$(pm_presets_dir)
++endif
+ 
+ # from https://stackoverflow.com/questions/30897170/ac-subst-does-not-expand-variable answer: https://stackoverflow.com/a/30960268
+ # ptomato https://stackoverflow.com/users/172999/ptomato
+diff --git a/configure.ac b/configure.ac
+index ca4faa40..fb38f9a7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -32,6 +32,7 @@ AS_IF([test "x$enable_emscripten" = "xyes" || test "x$EMSCRIPTEN" = "xyes"], [
+   enable_threading=no
+   enable_gles=yes
+   enable_sdl=yes
++  enable_preset_subdirs=no
+ ], [
+   dnl Running in a normal OS (not emscripten)
+   AX_CHECK_GL
+@@ -129,6 +130,13 @@ AC_ARG_ENABLE([gles],
+     AC_DEFINE([USE_GLES], [1], [Define USE_GLES])
+ ])
+ 
++AC_ARG_ENABLE([preset_subdirs],
++  AS_HELP_STRING([--enable-preset-subdirs], [Organize presets into subdirectories.]),
++  [], [enable_preset_subdirs=no])
++  AS_IF([test "x$enable_preset_subdirs" = "xyes"], [
++    AC_DEFINE([ENABLE_PRESET_SUBDIRS], [1], [Define ENABLE_PRESET_SUBDIRS])
++])
++
+ dnl LLVM
+ dnl unfortuately AX_LLVM macro seems to be out of date, so we're going to rely on the user to make sure LLVM is installed correctly
+ AC_ARG_ENABLE([llvm],
+@@ -214,6 +222,7 @@ AM_CONDITIONAL([ENABLE_QT], [test "x$enable_qt" = "xyes"])
+ AM_CONDITIONAL([ENABLE_JACK], [test "x$enable_jack" = "xyes"])
+ AM_CONDITIONAL([ENABLE_PULSEAUDIO], [test "x$enable_pulseaudio" = "xyes"])
+ AM_CONDITIONAL([ENABLE_EMSCRIPTEN], [test "x$enable_emscripten" = "xyes"])
++AM_CONDITIONAL([ENABLE_PRESET_SUBDIRS], [test "x$enable_preset_subdirs" = "xyes"])
+ 
+ 
+ my_CFLAGS="-Wall -Wchar-subscripts -Wformat-security -Wpointer-arith -Wshadow -Wsign-compare -Wtype-limits "
+@@ -255,4 +264,5 @@ Jack:                   ${enable_jack}
+ OpenGLES:               ${enable_gles}
+ Emscripten:             ${enable_emscripten}
+ llvm:                   ${enable_llvm}
++Preset subdirs:         ${enable_preset_subdirs}
+ ])
+-- 
+2.20.1
+

--- a/depends/common/projectm/CMakeLists.txt
+++ b/depends/common/projectm/CMakeLists.txt
@@ -13,6 +13,7 @@ externalproject_add(projectm
                       --disable-shared
                       --disable-qt
                       --disable-threading
+                      --enable-preset-subdirs
                       --prefix=${OUTPUT_DIR}
                       --with-pic ${PROJECTM_CONFIG}
                     INSTALL_COMMAND ""

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -290,7 +290,65 @@ bool CVisualizationProjectM::InitProjectM()
 
 void CVisualizationProjectM::ChoosePresetPack(int pvalue)
 {
-  m_UserPackFolder = pvalue == 1;
+  switch (pvalue)
+  {
+    case -1:
+      m_UserPackFolder = true;
+      break;
+
+    case 0:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_bltc201");
+      break;
+
+    case 1:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_milkdrop");
+      break;
+
+    case 2:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_milkdrop_104");
+      break;
+
+    case 3:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_milkdrop_200");
+      break;
+
+    case 4:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_mischa_collection");
+      break;
+
+    case 5:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_projectM");
+
+    case 6:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_stock");
+      break;
+
+    case 7:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_tryptonaut");
+      break;
+
+    case 8:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/presets_yin");
+      break;
+
+    case 9:
+      m_UserPackFolder = false;
+      m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets/tests");
+      break;
+
+    default:
+      kodi::Log(ADDON_LOG_FATAL, "CVisualizationProjectM::%s: Should never called with unknown preset pack (%i)", __func__, pvalue);
+      break;
+  }
 }
 
 void CVisualizationProjectM::ChooseUserPresetFolder(std::string pvalue)
@@ -300,10 +358,6 @@ void CVisualizationProjectM::ChooseUserPresetFolder(std::string pvalue)
     if (pvalue.back() == '/')
       pvalue.erase(pvalue.length()-1,1);  //Remove "/" from the end
     m_configPM.presetURL = pvalue;
-  }
-  else
-  {
-    m_configPM.presetURL = kodi::GetAddonPath("resources/projectM/presets");
   }
 }
 

--- a/visualization.projectm/addon.xml.in
+++ b/visualization.projectm/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.projectm"
-  version="2.3.0"
+  version="2.3.1"
   name="projectM"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/visualization.projectm/resources/language/resource.language.en_gb/strings.po
+++ b/visualization.projectm/resources/language/resource.language.en_gb/strings.po
@@ -74,7 +74,49 @@ msgctxt "#30013"
 msgid "General"
 msgstr ""
 
-#empty strings from id 30013 to 30049
+#empty strings from id 30013 to 30019
+
+msgctxt "#30020"
+msgid "bltc201"
+msgstr ""
+
+msgctxt "#30021"
+msgid "Milkdrop"
+msgstr ""
+
+msgctxt "#30022"
+msgid "Milkdrop 1.04"
+msgstr ""
+
+msgctxt "#30023"
+msgid "Milkdrop 2.00"
+msgstr ""
+
+msgctxt "#30024"
+msgid "Mischa's Collection"
+msgstr ""
+
+msgctxt "#30025"
+msgid "projectM"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Stock"
+msgstr ""
+
+msgctxt "#30027"
+msgid "Tryptonaut"
+msgstr ""
+
+msgctxt "#30028"
+msgid "Yin"
+msgstr ""
+
+msgctxt "#30029"
+msgid "Tests"
+msgstr ""
+
+#empty strings from id 30030 to 30049
 #setting value formats
 
 msgctxt "#30050"

--- a/visualization.projectm/resources/settings.xml
+++ b/visualization.projectm/resources/settings.xml
@@ -3,14 +3,23 @@
     <category id="main" label="30013" help="0">
       <group id="1" label="0">
         <setting id="preset_pack" type="integer" label="30009" help="0">
-          <default>0</default>
+          <default>5</default>
           <constraints>
             <options>
-              <option label="30010">0</option>
-              <option label="30011">1</option>
+              <option label="30020">0</option> <!-- bltc201 -->
+              <option label="30021">1</option> <!-- Milkdrop -->
+              <option label="30022">2</option> <!-- Milkdrop 1.04 -->
+              <option label="30023">3</option> <!-- Milkdrop 2.00 -->
+              <option label="30024">4</option> <!-- Mischa's Collection -->
+              <option label="30025">5</option> <!-- projectM -->
+              <option label="30026">6</option> <!-- Stock -->
+              <option label="30027">7</option> <!-- Tryptonaut -->
+              <option label="30028">8</option> <!-- Yin -->
+              <option label="30029">9</option> <!-- Tests -->
+              <option label="30011">-1</option> <!-- User Defined Preset Folder -->
             </options>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
         <setting id="user_preset_folder" type="path" label="30012" help="0">
           <default></default>
@@ -18,7 +27,7 @@
             <allowempty>true</allowempty>
           </constraints>
           <dependencies>
-            <dependency type="visible" setting="preset_pack" operator="is">1</dependency>
+            <dependency type="visible" setting="preset_pack" operator="is">-1</dependency>
           </dependencies>
           <control type="button" format="path"/>
         </setting>


### PR DESCRIPTION
Before was 2016 files in one folder, some was before present in different folders and overwritten several times during install.

This allow to select the wanted source by the addon settings.

To make this possible, unfortunately, a patch was required within ProjectM, as this always packed all the files only in one folder.

But find it so much better, as some of them were just for testing purposes and they do not really want to see them.

Regarding Debian something should be done, because this is not compatible (and apparently not before).

![Screenshot_20191005_145202](https://user-images.githubusercontent.com/6879739/66255095-f6dc3400-e77f-11e9-8366-c3a0be47d65e.png)