### PR TITLE
Jenkinsfile: Add macOS aarch64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Omega", platforms: ["android-armv7", "android-aarch64", "osx-x86_64", "ubuntu-ppa", "windows-i686", "windows-x86_64"])
+buildPlugin(version: "Omega", platforms: ["android-armv7", "android-aarch64", "osx-x86_64", "osx-arm64", "ubuntu-ppa", "windows-i686", "windows-x86_64"])

--- a/visualization.projectm/addon.xml.in
+++ b/visualization.projectm/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.projectm"
-  version="21.0.0"
+  version="21.0.1"
   name="projectM"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Build for macOS Apple Silicon (osx-arm64) was missing in the Jenkins file. Builds fine without changes. Runtime-tested and works.